### PR TITLE
Fix layout

### DIFF
--- a/ObjcQrExample/ViewController.m
+++ b/ObjcQrExample/ViewController.m
@@ -19,9 +19,9 @@
 
 @implementation ViewController
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+
     CGRect previewRect = [self makePreviewRectWithFrame:self.view.frame];
     self.maskLayerView.layer.mask = [self makeMaskWithRect:previewRect inFrame:self.maskLayerView.frame];
 


### PR DESCRIPTION
viewDidLoad でレイアウトを生成すると端末ではなく、 storyboard のサイズで計算されるため、それ以外の端末で表示した時にレイアウトが崩れてしまう。
viewDidLayoutSubviews で端末のサイズで計算するようにする。

fixes #1

## Screenshot

![Screen Shot 2022-01-15 at 16 32 03](https://user-images.githubusercontent.com/5770480/149613711-d156991f-399b-4ba3-8cdf-1762b6419776.png)
